### PR TITLE
Fix case-sensitive references vs files names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "clio-explorer",
-	"version": "0.0.22",
+	"version": "0.0.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "clio-explorer",
-			"version": "0.0.22",
+			"version": "0.0.24",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.32",

--- a/src/commands/BaseCommand.ts
+++ b/src/commands/BaseCommand.ts
@@ -1,5 +1,5 @@
 import exp = require("constants");
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 
 export abstract class BaseCommand {
 

--- a/src/commands/Clio.ts
+++ b/src/commands/Clio.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 import { FlushDb,IFlushDbArgs,IFlushDbResponse } from './FlushDbCommand';
 import { HealthCheck, IHealthCheckArgs, IHealthCheckResponse } from './HealthCheckCommand';

--- a/src/commands/Dev/GetPackagesCommandDev.ts
+++ b/src/commands/Dev/GetPackagesCommandDev.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../../Common/clioExecutor';
+import { ClioExecutor } from '../../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from '../BaseCommand';
 
 /**

--- a/src/commands/DownloadPackageCommand.ts
+++ b/src/commands/DownloadPackageCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/FlushDbCommand.ts
+++ b/src/commands/FlushDbCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/GetPackagesCommand.ts
+++ b/src/commands/GetPackagesCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/HealthCheckCommand.ts
+++ b/src/commands/HealthCheckCommand.ts
@@ -1,5 +1,5 @@
 
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/InstallGate.ts
+++ b/src/commands/InstallGate.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/LockPkgCommand.ts
+++ b/src/commands/LockPkgCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/RegisterWebAppCommand.ts
+++ b/src/commands/RegisterWebAppCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/RestoreConfiguration.ts
+++ b/src/commands/RestoreConfiguration.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/SqlCommand.ts
+++ b/src/commands/SqlCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 import * as fs from 'fs';
 import { rm, writeFile } from 'fs/promises';

--- a/src/commands/UnLockPkgCommand.ts
+++ b/src/commands/UnLockPkgCommand.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/commands/UnregWebApp.ts
+++ b/src/commands/UnregWebApp.ts
@@ -1,4 +1,4 @@
-import { ClioExecutor } from '../Common/clioExecutor';
+import { ClioExecutor } from '../common/clioExecutor';
 import { BaseCommand, ICanExecuteValidationResult, ICommand, ICommandArgs, ICommandResponse } from './BaseCommand';
 
 /**

--- a/src/common/CreatioClient/CreatioClient.ts
+++ b/src/common/CreatioClient/CreatioClient.ts
@@ -4,7 +4,7 @@ import { request as httpsRequest, RequestOptions} from "https";
 import { ColumnUsage, DataValueType, LogLevel, ParameterDirection, ProcessDataValueType } from "./enums";
 import { KnownRoutes } from "./KnownRoutes";
 import { ItemType } from "../../service/TreeItemProvider/ItemType";
-import { IRequestOptions, IResponse } from "../interfaces";
+import { IRequestOptions, IResponse } from "../Interfaces";
 import { HttpMethod } from "../Enums";
 import { WebSocket, ClientOptions } from 'ws';
 import { IConnectionSettings } from '../../service/TreeItemProvider/Environment';

--- a/src/common/MarketplaceClient/marketplaceClient.ts
+++ b/src/common/MarketplaceClient/marketplaceClient.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, OutgoingHttpHeaders } from "http";
 import { request as httpsRequest, RequestOptions} from "https";
 import { SemVer } from "semver";
 import { HttpMethod } from '../Enums';
-import { IRequestOptions, IResponse } from '../interfaces';
+import { IRequestOptions, IResponse } from '../Interfaces';
 import { CompatiblePlatform, DbmsCompatibility, MarketplaceApp, ModerationState, ProductCategory } from './marketplaceApp';
 
 export class MarketplaceClient{

--- a/src/common/NugetClient/NugetClient.ts
+++ b/src/common/NugetClient/NugetClient.ts
@@ -2,7 +2,7 @@ import { ClientRequest, IncomingMessage, OutgoingHttpHeaders } from "http";
 import { RequestOptions } from "https";
 import { request as httpRequest } from "http";
 import { request as httpsRequest} from "https";
-import { IRequestOptions, IResponse } from "../interfaces";
+import { IRequestOptions, IResponse } from "../Interfaces";
 import { HttpMethod } from "../Enums";
 import { isArrayBufferView } from "util/types";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { Clio } from './commands/Clio';
 import { IRegisterWebAppArgs } from './commands/RegisterWebAppCommand';
 import { TextEditor } from 'vscode';
 import { ConnectionPanel, FormData } from './panels/ConnectionPanel';
-import { ClioExecutor } from './Common/clioExecutor';
+import { ClioExecutor } from './common/clioExecutor';
 import { CreatioTreeItemProvider } from './service/TreeItemProvider/CreatioTreeItemProvider';
 import { Environment, IConnectionSettings } from './service/TreeItemProvider/Environment';
 import { CatalogPanel } from './panels/CatalogPanel';

--- a/src/panels/CatalogPanel.ts
+++ b/src/panels/CatalogPanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 import { MarketplaceCatalogue } from "../common/MarketplaceClient/MarketplaceCatalogue";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";

--- a/src/panels/ComparePanel.ts
+++ b/src/panels/ComparePanel.ts
@@ -1,7 +1,7 @@
 import { env } from "process";
 import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 import { IFeature } from "../common/CreatioClient/CreatioClient";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";

--- a/src/panels/ConnectionPanel.ts
+++ b/src/panels/ConnectionPanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "./getNonce";

--- a/src/panels/FeaturesPanel.ts
+++ b/src/panels/FeaturesPanel.ts
@@ -1,7 +1,7 @@
 import { env } from "process";
 import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 import { IFeature } from "../common/CreatioClient/CreatioClient";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";

--- a/src/panels/SqlPanel.ts
+++ b/src/panels/SqlPanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
-import { ClioExecutor } from "../Common/clioExecutor";
+import { ClioExecutor } from "../common/clioExecutor";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";
 

--- a/src/panels/WebSocketMessagesPanel.ts
+++ b/src/panels/WebSocketMessagesPanel.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { Disposable, Webview, WebviewPanel, window, Uri, ViewColumn } from "vscode";
 import { IWebSocketMessage } from "../common/CreatioClient/CreatioClient";
 import { LogLevel } from "../common/CreatioClient/enums";
-//import { ClioExecutor } from "../Common/clioExecutor";
+//import { ClioExecutor } from "../common/clioExecutor";
 import { Environment } from "../service/TreeItemProvider/Environment";
 import { getUri } from "../utilities/getUri";
 

--- a/src/service/TreeItemProvider/CreatioTreeItemProvider.ts
+++ b/src/service/TreeItemProvider/CreatioTreeItemProvider.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import path = require('path');
 import { CreatioTreeItem } from './CreatioTreeItem';
 import { Environment, IConnectionSettings } from './Environment';
-import { ClioExecutor } from '../../Common/clioExecutor';
+import { ClioExecutor } from '../../common/clioExecutor';
 
 export class CreatioTreeItemProvider implements vscode.TreeDataProvider<CreatioTreeItem>{
 	

--- a/src/service/TreeItemProvider/Environment.ts
+++ b/src/service/TreeItemProvider/Environment.ts
@@ -8,7 +8,7 @@ import { CreatioTreeItem } from "./CreatioTreeItem";
 import { ItemType } from "./ItemType";
 import { IHealthCheckArgs } from '../../commands/HealthCheckCommand';
 import { CreatioClient, IFeature, IWebSocketMessage } from '../../common/CreatioClient/CreatioClient';
-import { ClioExecutor } from '../../Common/clioExecutor';
+import { ClioExecutor } from '../../common/clioExecutor';
 import { IRestoreConfigurationArgs } from '../../commands/RestoreConfiguration';
 import { IFlushDbArgs } from '../../commands/FlushDbCommand';
 import { ISqlArgs } from '../../commands/SqlCommand';

--- a/src/service/workspaceTreeViewProvider/WorkspaceTreeViewProvider.ts
+++ b/src/service/workspaceTreeViewProvider/WorkspaceTreeViewProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import path = require('path');
 import { mySemVer } from '../../utilities/mySemVer';
-import { ClioExecutor } from '../../Common/clioExecutor';
+import { ClioExecutor } from '../../common/clioExecutor';
 import { execSync } from 'child_process';
 import { Environment } from '../TreeItemProvider/Environment';
 import { env } from 'process';


### PR DESCRIPTION
Many reference like ../Common are with the file name common (non capital) that is braking the extension in Linux environments.